### PR TITLE
Posicionando imagens e tabelas no topo de páginas em branco

### DIFF
--- a/doc/latex/abntex2/examples/abntex2-modelo-trabalho-academico.tex
+++ b/doc/latex/abntex2/examples/abntex2-modelo-trabalho-academico.tex
@@ -140,6 +140,14 @@ as normas ABNT apresentado à comunidade de usuários \LaTeX.}
 \makeatother
 % --- 
 
+% ---
+% Posiciona figuras e tabelas no topo da página quando adicionadas sozinhas
+% em um página em branco. Ver https://github.com/abntex/abntex2/issues/170
+\makeatletter
+\setlength{\@fptop}{5pt} % Set distance from top of page to first float
+\makeatother
+% ---
+
 % --- 
 % Espaçamentos entre linhas e parágrafos 
 % --- 


### PR DESCRIPTION
Esse codigo configura o posicionamento de tabelas e imagens em paginas em branco. Isso so ocorre quando ela nao coube na pagina anterior e foi posicionada na proxima pagina.

Anteriormente ela era posiconada no topo da pagina. Considero que posiciconar no topo seria um comportamento mais apropriado.

closes #170