### PR TITLE
Pequena correção no modelo de trabalho acadêmico

### DIFF
--- a/doc/latex/abntex2/examples/abntex2-modelo-trabalho-academico.tex
+++ b/doc/latex/abntex2/examples/abntex2-modelo-trabalho-academico.tex
@@ -224,6 +224,7 @@ as normas ABNT apresentado à comunidade de usuários \LaTeX.}
 % com o documento, salve-o como PDF no diretório do seu projeto e substitua todo
 % o conteúdo de implementação deste arquivo pelo comando abaixo:
 %
+% \usepackage{pdfpages}		% necessário para comando \includepdf
 % \begin{fichacatalografica}
 %     \includepdf{fig_ficha_catalografica.pdf}
 % \end{fichacatalografica}


### PR DESCRIPTION
Necessário incluir pacote `pdfpages` para comando `\includepdf`, utilizado para incluir ficha catalográfica.