### PR TITLE
Setting alineas environment to new enumitem package specifications

### DIFF
--- a/tex/latex/abntex2/abntex2.cls
+++ b/tex/latex/abntex2/abntex2.cls
@@ -990,7 +990,7 @@
 % Ambiente para alineas e e subalineas (incisos)
 % ABNT NBR 6024/2012 - 4.2 e 4.3
 \newlist{alineas}{enumerate}{2}
-\setlist[alineas,1]{label={\alph*)},topsep=0pt,itemsep=0pt,leftmargin=\parindent+\labelwidth-\labelsep}%
+\setlist[alineas,1]{label={\alph*)},topsep=0pt,itemsep=0pt,left=\parindent}%
 \setlist[alineas,2]{label={--},topsep=0pt,itemsep=0pt,leftmargin=*}
 \newlist{subalineas}{enumerate}{1}
 \setlist[subalineas,1]{label={--},topsep=0pt,itemsep=0pt,leftmargin=*}%


### PR DESCRIPTION
A versão 3.6 do enumitem aparentemente não aceita mais a aritimética com os contadores para a definição da leftmargin. Provavelmente essa solução não é adequada, mas as alineas estão sendo impressas com um sinal de "+" com essa nova atualização do enumitem (30/11/2018) e não encontrei outra forma de removê-lo