### PR TITLE
Corrigido o espaço do título dos apêndices sendo colocado no lugar errado

### DIFF
--- a/tex/latex/abntex2/abntex2.cls
+++ b/tex/latex/abntex2/abntex2.cls
@@ -618,11 +618,12 @@
      \tocprintchapter
      \setboolean{abntex@innonumchapter}{false}
      \chapnumfont%
-     \space\thechapter\space%
+     \space\thechapter%
      \ifthenelse{\boolean{abntex@apendiceousecao}}{%
        \tocinnonumchapter
        \ABNTEXcaptiondelim%
      }{} % else
+     \space
   }
   \renewcommand{\afterchapternum}{}
   

--- a/tex/latex/abntex2/abntex2.cls
+++ b/tex/latex/abntex2/abntex2.cls
@@ -622,8 +622,8 @@
      \ifthenelse{\boolean{abntex@apendiceousecao}}{%
        \tocinnonumchapter
        \ABNTEXcaptiondelim%
-     }{} % else
-     \space
+     }{}%
+     \space%
   }
   \renewcommand{\afterchapternum}{}
   


### PR DESCRIPTION
Antes dessa correção:
![image](https://user-images.githubusercontent.com/5332158/67066674-f82b3a80-f149-11e9-9fa8-767044c8a5aa.png)

Depois dessa correção:
![image](https://user-images.githubusercontent.com/5332158/67066707-1002be80-f14a-11e9-898d-115a91b1d25a.png)

