### PR TITLE
Update abntex2-num.bst

### DIFF
--- a/bibtex/bst/abntex2/abntex2-num.bst
+++ b/bibtex/bst/abntex2/abntex2-num.bst
@@ -2041,7 +2041,7 @@ FUNCTION {set.default.abnt.variables}
   abnt.doi.expand.to.url 'abnt.doi :=
   #3 'abnt.etal.cite :=
   #3 'abnt.etal.list :=
-  "et al." 'abnt.etal.text :=
+  "\textit{et al.}" 'abnt.etal.text :=
   #0 'abnt.full.initials :=
   #0 'abnt.last.names :=      %#0 abnt-style, #1 bibtex-style
   #1 'abnt.ldots.type :=      %#0 use nothing, #1 use \ldots, #2 use $\ldots$, 3# use {...}


### PR DESCRIPTION
A Associação Brasileira de Normas Técnicas (ABNT) atualizou a NBR 10520 em julho de 2023, estabelecendo que a expressão latina "et al." deve ser grafada em itálico em citações de obras com mais de três autores. Anteriormente, a NBR 6023:2018 já havia introduzido essa recomendação para referências bibliográficas. Portanto, desde a atualização de 2023, o uso de "et al." em itálico é uma exigência tanto nas citações quanto nas referências, conforme as normas da ABNT.